### PR TITLE
[squid:S2259] Null pointers should not be dereferenced

### DIFF
--- a/app/src/main/java/com/example/android/apis/app/ActionBarShareActionProviderActivity.java
+++ b/app/src/main/java/com/example/android/apis/app/ActionBarShareActionProviderActivity.java
@@ -111,12 +111,14 @@ public class ActionBarShareActionProviderActivity extends Activity {
             /* ignore */
         } finally {
             try {
-                inputStream.close();
+                if (inputStream != null)
+                    inputStream.close();
             } catch (IOException ioe) {
                /* ignore */
             }
             try {
-                outputStream.close();
+                if (outputStream != null)
+                    outputStream.close();
             } catch (IOException ioe) {
                /* ignore */
             }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2259 - “Null pointers should not be dereferenced”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2259

Please let me know if you have any questions.
Ayman Abdelghany.
